### PR TITLE
Modernize CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ find_library( GMPXX_LIBRARY gmpxx REQUIRED )
 find_path( GMPXX_INCLUDE_DIR gmpxx.h REQUIRED )
 
 find_library( PARI_LIBRARY pari )
-find_path( PARI_INCLUDE_DIR pari.h )
+find_path( PARI_INCLUDE_DIR pari/pari.h )
 
 # ------------------------------------------------------------------
 # Set up targets
@@ -61,10 +61,9 @@ endif()
 if( PARI_LIBRARY )
 	add_library( coxiter_pari STATIC lib/paripolynomials.cpp growthrate.cpp signature.cpp )
 	target_link_libraries( coxiter_pari PUBLIC ${GMP_LIBRARY} ${GMPXX_LIBRARY} ${PARI_LIBRARY} )
-	target_include_directories( coxiter_pari PUBLIC ${GMPXX_INCLUDE_DIR} )
+	target_include_directories( coxiter_pari PUBLIC ${GMPXX_INCLUDE_DIR} ${PARI_INCLUDE_DIR} )
 	
 	target_link_libraries( coxiter PRIVATE coxiter_pari )
-	target_link_libraries( coxiter PRIVATE  )
 	add_definitions(-D_COMPILE_WITH_PARI_)
 else()
 	message( WARNING "Warning: PARI library was not found. CoxIter won't be able to compute growth rate and signature." )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,58 +1,70 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(coxiter)
-
-add_definitions("-std=c++11")
-if( CYGWIN )
-	add_definitions("-std=gnu++11")
+# Taken from https://blog.kitware.com/cmake-and-the-default-build-type/
+# Set a default build type if none was specified.
+# This must precede the project() line, which would set the CMAKE_BUILD_TYPE
+# to 'Debug' with single-config generators on Windows.
+set(default_build_type "Release")
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT isMultiConfig AND NOT CMAKE_BUILD_TYPE)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-add_definitions("-Wall")
-add_definitions("-Wno-reorder")
-add_definitions("-Wno-unknown-pragmas")
+project(coxiter)
 
-set( CMAKE_BUILD_TYPE Release )
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# Main files
-add_executable(coxiter index2.cpp lib/string.cpp lib/regexp.cpp coxiter.cpp arithmeticity.cpp app.cpp main.cpp)
-
-# Maths: polynomials, fractions, varia functions
-add_library( coxiter_maths STATIC lib/math_tools.cpp lib/polynomials.cpp lib/numbers/number_template.cpp lib/numbers/mpz_rational.cpp )
-target_link_libraries( coxiter coxiter_maths )
-
-# Graphs: graphs, products of graphs and iterators
-add_library( coxiter_graphs STATIC graphs.product.set.cpp graphs.product.cpp graphs.list.n.cpp graphs.list.iterator.cpp graphs.list.cpp graph.cpp  )
-target_link_libraries( coxiter coxiter_graphs )
+if(NOT MSVC)
+	add_compile_options(-Wall -Wno-reorder -Wno-unknown-pragmas)
+endif()
 
 # ------------------------------------------------------------------
 # External libraries
 find_package( OpenMP )
-if( OPENMP_FOUND )
-	target_link_libraries( coxiter OpenMP::OpenMP_CXX )
-endif()
 
-find_library( PCRE_LIBRARY pcre )
-target_link_libraries( coxiter ${PCRE_LIBRARY} )
+find_library( PCRE_LIBRARY pcre REQUIRED )
+find_path( PCRE_INCLUDE_DIR pcre.h REQUIRED )
 
-find_library( GMP_LIBRARY gmp )
-target_link_libraries( coxiter ${GMP_LIBRARY} )
-# find <gmpxx.h> in APPLE
-if( APPLE )
-	set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I/usr/local/include" )
-	set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I/usr/local/include" )
-endif()
+find_library( GMP_LIBRARY gmp REQUIRED )
 
-find_library( GMP_LIBRARYXX gmpxx )
-target_link_libraries( coxiter ${GMP_LIBRARYXX} )
+find_library( GMPXX_LIBRARY gmpxx REQUIRED )
+find_path( GMPXX_INCLUDE_DIR gmpxx.h REQUIRED )
 
 find_library( PARI_LIBRARY pari )
+find_path( PARI_INCLUDE_DIR pari.h )
+
+# ------------------------------------------------------------------
+# Set up targets
+
+# Maths: polynomials, fractions, varia functions
+add_library( coxiter_maths STATIC lib/math_tools.cpp lib/polynomials.cpp lib/numbers/number_template.cpp lib/numbers/mpz_rational.cpp )
+target_link_libraries( coxiter_maths PUBLIC ${GMP_LIBRARY} ${GMPXX_LIBRARY} )
+target_include_directories( coxiter_maths PUBLIC ${GMPXX_INCLUDE_DIR} )
+
+# Graphs: graphs, products of graphs and iterators
+add_library( coxiter_graphs STATIC graphs.product.set.cpp graphs.product.cpp graphs.list.n.cpp graphs.list.iterator.cpp graphs.list.cpp graph.cpp  )
+
+# Main files
+add_executable(coxiter index2.cpp lib/string.cpp lib/regexp.cpp coxiter.cpp arithmeticity.cpp app.cpp main.cpp)
+target_link_libraries( coxiter PUBLIC ${PCRE_LIBRARY} )
+target_include_directories( coxiter PUBLIC ${PCRE_INCLUDE_DIR} )
+target_link_libraries( coxiter PRIVATE coxiter_maths coxiter_graphs )
+
+if( OpenMP_FOUND )
+	target_link_libraries( coxiter PRIVATE OpenMP::OpenMP_CXX )
+endif()
+
 if( PARI_LIBRARY )
 	add_library( coxiter_pari STATIC lib/paripolynomials.cpp growthrate.cpp signature.cpp )
-	target_link_libraries( coxiter_pari ${GMP_LIBRARY} )
-	target_link_libraries( coxiter_pari ${GMP_LIBRARYXX} )
-	target_link_libraries( coxiter coxiter_pari )
+	target_link_libraries( coxiter_pari PUBLIC ${GMP_LIBRARY} ${GMPXX_LIBRARY} ${PARI_LIBRARY} )
+	target_include_directories( coxiter_pari PUBLIC ${GMPXX_INCLUDE_DIR} )
 	
-	target_link_libraries( coxiter ${PARI_LIBRARY} )
+	target_link_libraries( coxiter PRIVATE coxiter_pari )
+	target_link_libraries( coxiter PRIVATE  )
 	add_definitions(-D_COMPILE_WITH_PARI_)
 else()
 	message( WARNING "Warning: PARI library was not found. CoxIter won't be able to compute growth rate and signature." )


### PR DESCRIPTION
This cleans up CMakeLists.txt a bit and makes it work on more systems, e.g. by explicitly looking for the header files that are used. (Now it works on my system, where libraries were installed with MacPorts.)

You may want to update the compilation instructions. I expect on most systems it should work with the following standard commands:

```
mkdir build && cd build
cmake ..
cmake --build .
```

If you want to add MacPorts instructions to the OS X section, the prerequisites can be installed with `sudo port install cmake gmp pcre pari graphviz`.