### PR TITLE
added gmp-devel to necessary packages for fedora

### DIFF
--- a/docs/page_install.html
+++ b/docs/page_install.html
@@ -105,7 +105,7 @@ Compilation with GNU/Linux</h1>
 Preliminaries</h2>
 <p>First, install everything you will need to compile the program.</p>
 <p>On Ubuntu, Linux Mint or any Debian-based distribution, type the following commands in a Shell: </p><div class="fragment"><div class="line">sudo apt-get install g++ cmake graphviz libpcre3-dev libpari-dev libgmp-dev git</div>
-</div><!-- fragment --><p>On Fedora, type the following commands in a Shell: </p><div class="fragment"><div class="line">sudo dnf install g++ cmake graphviz pcre-devel pari-devel git</div>
+</div><!-- fragment --><p>On Fedora, type the following commands in a Shell: </p><div class="fragment"><div class="line">sudo dnf install g++ cmake graphviz pcre-devel pari-devel gmp-devel git</div>
 </div><!-- fragment --><h2><a class="anchor" id="main_compilation_gnu_compile"></a>
 Compilation</h2>
 <p>With a shell, go to the directory where you want to install CoxIter and type the following: </p><div class="fragment"><div class="line">git clone https:<span class="comment">//github.com/rgugliel/CoxIter</span></div>

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -82,7 +82,7 @@ sudo apt-get install g++ cmake graphviz libpcre3-dev libpari-dev libgmp-dev git
 
 On Fedora, type the following commands in a Shell:
 \code
-sudo dnf install g++ cmake graphviz pcre-devel pari-devel git
+sudo dnf install g++ cmake graphviz pcre-devel pari-devel gmp-devel git
 \endcode
 
 \subsection main_compilation_gnu_compile Compilation


### PR DESCRIPTION
Hi @rgugliel 

I tried to install CoxIter on Fedora and gmp-devel was missing in the install command for dnf.
I added it in the documentation - manually in both places. I'm not entirely sure that that's the correct way, but I hope so...
